### PR TITLE
Initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Another Signal Slot
 > Signal/Slot implementation with a focus on automatic connection handling
 
+[![Github Releases](https://img.shields.io/github/release/michaelcowan/ass.svg)](https://github.com/michaelcowan/ass/releases)
 [![Build Status](https://travis-ci.org/michaelcowan/ass.svg?branch=master)](https://travis-ci.org/michaelcowan/ass)
 [![Coverage Status](https://coveralls.io/repos/github/michaelcowan/ass/badge.svg?branch=master)](https://coveralls.io/github/michaelcowan/ass?branch=master)
 

--- a/ass.hpp
+++ b/ass.hpp
@@ -132,6 +132,15 @@ public:
     };
 
     /**
+     * Copies all connections of other Signal to this Signal then disconnects other Signal.
+     * @param other Signal to copy connections from.
+     */
+    Signal(Signal &&other) noexcept {
+        copyFrom(other);
+        other.disconnectAll();
+    }
+
+    /**
      * Connects this Signal to the provided Slot unless already connected.
      *
      * @param slot Slot to connect this Signal to.

--- a/ass.hpp
+++ b/ass.hpp
@@ -102,10 +102,19 @@ public:
      * @param other Signal to copy connections from.
      */
     Signal(const Signal &other) {
-        for (auto *slot : other.slots) {
-            this->connect(*slot);
-        }
+        copyFrom(other);
     }
+
+    /**
+     * Replaces connections of this Signal with connections of other Signal.
+     * @param other Signal to copy connections from.
+     * @return Copy assigned instance.
+     */
+    Signal &operator=(const Signal &other) {
+        disconnectAll();
+        copyFrom(other);
+        return *this;
+    };
 
     /**
      * Connects this Signal to the provided Slot.
@@ -160,6 +169,12 @@ private:
 
     void disconnectFrom(Slot<Args...> &slot) {
         slots.erase(std::remove(slots.begin(), slots.end(), &slot), slots.end());
+    }
+
+    void copyFrom(const Signal<Args...> &other) {
+        for (auto *slot : other.slots) {
+            this->connect(*slot);
+        }
     }
 
 private:

--- a/ass.hpp
+++ b/ass.hpp
@@ -31,6 +31,16 @@ public:
     }
 
     /**
+     * Copies all connections of other Slot to this Slot.
+     * @param other Slot to copy connections from.
+     */
+    Slot(const Slot &other) {
+        for (auto *signal : other.signals) {
+            signal->connect(*this);
+        }
+    }
+
+    /**
      * Returns the number of connections for this Slot.
      *
      * @return Number of connections for this Slot.

--- a/ass.hpp
+++ b/ass.hpp
@@ -60,7 +60,7 @@ private:
     }
 
     void disconnectFromAll() {
-        for (auto * signal : signals) {
+        for (auto *signal : signals) {
             signal->disconnectFrom(*this);
         }
         signals.clear();
@@ -88,6 +88,16 @@ public:
     }
 
     /**
+     * Copies all connections of other Signal to this Signal.
+     * @param other Signal to copy connections from.
+     */
+    Signal(const Signal &other) {
+        for (auto *slot : other.slots) {
+            this->connect(*slot);
+        }
+    }
+
+    /**
      * Connects this Signal to the provided Slot.
      *
      * @param slot Slot to connect this Signal to.
@@ -111,7 +121,7 @@ public:
      * Disconnects this Signal from all connected Slot.
      */
     void disconnectAll() {
-        for (auto * slot : slots) {
+        for (auto *slot : slots) {
             slot->disconnectFrom(*this);
         }
         slots.clear();

--- a/ass.hpp
+++ b/ass.hpp
@@ -91,6 +91,16 @@ public:
     }
 
     /**
+     * Disconnects this Signal from all connected Slot.
+     */
+    void disconnectAll() {
+        for (auto * slot : slots) {
+            slot->disconnectFrom(*this);
+        }
+        slots.clear();
+    }
+
+    /**
      * Returns the number of connections for this Signal.
      *
      * @return Number of connections for this Signal.

--- a/ass.hpp
+++ b/ass.hpp
@@ -51,6 +51,10 @@ private:
         signals.push_back(&signal);
     }
 
+    void disconnectFrom(Signal<Args...> &signal) {
+        signals.erase(std::remove(signals.begin(), signals.end(), &signal), signals.end());
+    }
+
 private:
 
     std::function<void(Args...)> callback;
@@ -74,6 +78,16 @@ public:
     void connect(Slot<Args...> &slot) {
         slots.push_back(&slot);
         slot.connectTo(*this);
+    }
+
+    /**
+     * Disconnects this Signal from the provided Slot if connected.
+     *
+     * @param slot Slot to disconnect this Signal from.
+     */
+    void disconnect(Slot<Args...> &slot) {
+        slots.erase(std::remove(slots.begin(), slots.end(), &slot), slots.end());
+        slot.disconnectFrom(*this);
     }
 
     /**

--- a/ass.hpp
+++ b/ass.hpp
@@ -132,13 +132,15 @@ public:
     };
 
     /**
-     * Connects this Signal to the provided Slot.
+     * Connects this Signal to the provided Slot unless already connected.
      *
      * @param slot Slot to connect this Signal to.
      */
     void connect(Slot<Args...> &slot) {
-        slots.push_back(&slot);
-        slot.connectTo(*this);
+        if (!isConnectedTo(slot)) {
+            slots.push_back(&slot);
+            slot.connectTo(*this);
+        }
     }
 
     /**

--- a/ass.hpp
+++ b/ass.hpp
@@ -59,6 +59,19 @@ public:
     }
 
     /**
+     * Replaces connections of this Slot with connections of other Slot then disconnects other
+     * Slot.
+     * @param other Slot to copy connections from.
+     * @return Move assigned instance.
+     */
+    Slot &operator=(Slot &&other) noexcept {
+        disconnectAll();
+        copyConnectionsFrom(other);
+        other.disconnectAll();
+        return *this;
+    }
+
+    /**
      * Returns the number of connections for this Slot.
      *
      * @return Number of connections for this Slot.

--- a/ass.hpp
+++ b/ass.hpp
@@ -150,6 +150,19 @@ public:
     }
 
     /**
+     * Replaces connections of this Signal with connections of other Signal then disconnects other
+     * Signal.
+     * @param other Signal to copy connections from.
+     * @return Move assigned instance.
+     */
+    Signal &operator=(Signal &&other) noexcept {
+        disconnectAll();
+        copyConnectionsFrom(other);
+        other.disconnectAll();
+        return *this;
+    }
+
+    /**
      * Connects this Signal to the provided Slot unless already connected.
      *
      * @param slot Slot to connect this Signal to.

--- a/ass.hpp
+++ b/ass.hpp
@@ -50,6 +50,15 @@ public:
     };
 
     /**
+     * Copies all connections of other Slot to this Slot then disconnects other Slot.
+     * @param other Slot to copy connections from.
+     */
+    Slot(Slot &&other) noexcept {
+        copyFrom(other);
+        other.disconnectFromAll();
+    }
+
+    /**
      * Returns the number of connections for this Slot.
      *
      * @return Number of connections for this Slot.

--- a/ass.hpp
+++ b/ass.hpp
@@ -12,3 +12,91 @@
  */
 
 #pragma once
+
+template<typename... Args>
+class Signal;
+
+template<typename... Args>
+class Slot final {
+
+    friend class Signal<Args...>;
+
+public:
+
+    explicit Slot(std::function<void(Args...)> callback)
+            : callback(std::move(callback)) {}
+
+    /**
+     * Returns the number of connections for this Slot.
+     *
+     * @return Number of connections for this Slot.
+     */
+    int connectionCount() const {
+        return signals.size();
+    }
+
+    /**
+     * Returns true if this Slot is connected to the provided Signal.
+     *
+     * @param signal Signal to test connection against.
+     * @return true if connected.
+     */
+    bool isConnectedTo(const Signal<Args...> &signal) const {
+        return std::find(signals.begin(), signals.end(), &signal) != signals.end();
+    }
+
+private:
+
+    void connectTo(Signal<Args...> &signal) {
+        signals.push_back(&signal);
+    }
+
+private:
+
+    std::function<void(Args...)> callback;
+
+    std::vector<Signal<Args...> *> signals;
+
+};
+
+template<typename... Args>
+class Signal final {
+
+public:
+
+    Signal() = default;
+
+    /**
+     * Connects this Signal to the provided Slot.
+     *
+     * @param slot Slot to connect this Signal to.
+     */
+    void connect(Slot<Args...> &slot) {
+        slots.push_back(&slot);
+        slot.connectTo(*this);
+    }
+
+    /**
+     * Returns the number of connections for this Signal.
+     *
+     * @return Number of connections for this Signal.
+     */
+    int connectionCount() const {
+        return slots.size();
+    }
+
+    /**
+     * Returns true if this Signal is connected to the provided Slot.
+     *
+     * @param slot Slot to test connection against.
+     * @return true if connected.
+     */
+    bool isConnectedTo(const Slot<Args...> &slot) const {
+        return std::find(slots.begin(), slots.end(), &slot) != slots.end();
+    }
+
+private:
+
+    std::vector<Slot<Args...> *> slots;
+
+};

--- a/ass.hpp
+++ b/ass.hpp
@@ -35,10 +35,19 @@ public:
      * @param other Slot to copy connections from.
      */
     Slot(const Slot &other) {
-        for (auto *signal : other.signals) {
-            signal->connect(*this);
-        }
+        copyFrom(other);
     }
+
+    /**
+     * Replaces connections of this Slot with connections of other Slot.
+     * @param other Slot to copy connections from.
+     * @return Copy assigned instance.
+     */
+    Slot &operator=(const Slot &other) {
+        disconnectFromAll();
+        copyFrom(other);
+        return *this;
+    };
 
     /**
      * Returns the number of connections for this Slot.
@@ -74,6 +83,12 @@ private:
             signal->disconnectFrom(*this);
         }
         signals.clear();
+    }
+
+    void copyFrom(const Slot<Args...> &other) {
+        for (auto *signal : other.signals) {
+            signal->connect(*this);
+        }
     }
 
 private:

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -685,3 +685,69 @@ TEST_CASE("Signal can be move assigned after being previously connected") {
         REQUIRE_FALSE(moved.isConnectedTo(previousSlot));
     }
 }
+
+TEST_CASE("Slot can be move assigned") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Slot<> moved([]() {});
+
+    moved = std::move(slot);
+
+    SECTION("moved Slot should have a single connection") {
+        REQUIRE(moved.connectionCount() == 1);
+    }
+
+    SECTION("Signal should have a single connection") {
+        REQUIRE(signal.connectionCount() == 1);
+    }
+
+    SECTION("moved Slot should be connected to Signal") {
+        REQUIRE(moved.isConnectedTo(signal));
+    }
+
+    SECTION("Signal should be connected to moved Slot") {
+        REQUIRE(signal.isConnectedTo(moved));
+    }
+}
+
+TEST_CASE("Slot can be move assigned after being previously connected") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Slot<> moved([]() {});
+    Signal<> previousSignal;
+    previousSignal.connect(moved);
+
+    moved = std::move(slot);
+
+    SECTION("moved Slot should have a single connection") {
+        REQUIRE(moved.connectionCount() == 1);
+    }
+
+    SECTION("Signal should have a single connection") {
+        REQUIRE(signal.connectionCount() == 1);
+    }
+
+    SECTION("previous Signal should have zero connections") {
+        REQUIRE(previousSignal.connectionCount() == 0);
+    }
+
+    SECTION("moved Slot should be connected to Signal") {
+        REQUIRE(moved.isConnectedTo(signal));
+    }
+
+    SECTION("Signal should be connected to moved Slot") {
+        REQUIRE(signal.isConnectedTo(moved));
+    }
+
+    SECTION("previous Signal should not be connected to moved Slot") {
+        REQUIRE_FALSE(previousSignal.isConnectedTo(moved));
+    }
+
+    SECTION("moved Slot should not be connected to the previous Signal") {
+        REQUIRE_FALSE(moved.isConnectedTo(previousSignal));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1,4 +1,146 @@
 #define CATCH_CONFIG_MAIN
+
 #include "catch/catch.hpp"
 
 #include "../ass.hpp"
+
+TEST_CASE("a new Signal should have no connections") {
+    Signal<> signal;
+
+    REQUIRE(signal.connectionCount() == 0);
+}
+
+TEST_CASE("a new Slot should have no connections") {
+    Slot<> slot([]() {});
+
+    REQUIRE(slot.connectionCount() == 0);
+}
+
+TEST_CASE("Signal and Slot can be connected") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+
+    signal.connect(slot);
+
+    SECTION("Signal should have a single connection") {
+        REQUIRE(signal.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have a single connection") {
+        REQUIRE(slot.connectionCount() == 1);
+    }
+
+    SECTION("Signal should be connected to Slot") {
+        REQUIRE(signal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to Signal") {
+        REQUIRE(slot.isConnectedTo(signal));
+    }
+
+    SECTION("Signal should not be connected to another Slot") {
+        Slot<> anotherSlot([]() {});
+
+        REQUIRE_FALSE(signal.isConnectedTo(anotherSlot));
+    }
+
+    SECTION("Slot should not be connected to another Signal") {
+        Signal<> anotherSignal;
+
+        REQUIRE_FALSE(slot.isConnectedTo(anotherSignal));
+    }
+}
+
+TEST_CASE("Signal can be connected to multiple Slots") {
+    Signal<> signal;
+    Slot<> slot1([]() {});
+    Slot<> slot2([]() {});
+    Slot<> slot3([]() {});
+
+    signal.connect(slot1);
+    signal.connect(slot2);
+    signal.connect(slot3);
+
+    SECTION("Signal should have three connections") {
+        REQUIRE(signal.connectionCount() == 3);
+    }
+
+    SECTION("each Slot should have a single connection") {
+        REQUIRE(slot1.connectionCount() == 1);
+        REQUIRE(slot2.connectionCount() == 1);
+        REQUIRE(slot3.connectionCount() == 1);
+    }
+
+    SECTION("Signal should be connected to each Slot") {
+        REQUIRE(signal.isConnectedTo(slot1));
+        REQUIRE(signal.isConnectedTo(slot2));
+        REQUIRE(signal.isConnectedTo(slot3));
+    }
+
+    SECTION("each Slot should be connected to Signal") {
+        REQUIRE(slot1.isConnectedTo(signal));
+        REQUIRE(slot2.isConnectedTo(signal));
+        REQUIRE(slot3.isConnectedTo(signal));
+    }
+
+    SECTION("Signal should not be connected to another Slot") {
+        Slot<> anotherSlot([]() {});
+
+        REQUIRE_FALSE(signal.isConnectedTo(anotherSlot));
+    }
+
+    SECTION("each Slot should not be connected to another Signal") {
+        Signal<> anotherSignal;
+
+        REQUIRE_FALSE(slot1.isConnectedTo(anotherSignal));
+        REQUIRE_FALSE(slot2.isConnectedTo(anotherSignal));
+        REQUIRE_FALSE(slot3.isConnectedTo(anotherSignal));
+    }
+}
+
+TEST_CASE("Slot can be connected to multiple Signals") {
+    Signal<> signal1;
+    Signal<> signal2;
+    Signal<> signal3;
+    Slot<> slot([]() {});
+
+    signal1.connect(slot);
+    signal2.connect(slot);
+    signal3.connect(slot);
+
+    SECTION("each Signal should have a single connection") {
+        REQUIRE(signal1.connectionCount() == 1);
+        REQUIRE(signal2.connectionCount() == 1);
+        REQUIRE(signal3.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have a three connections") {
+        REQUIRE(slot.connectionCount() == 3);
+    }
+
+    SECTION("each Signal should be connected to Slot") {
+        REQUIRE(signal1.isConnectedTo(slot));
+        REQUIRE(signal2.isConnectedTo(slot));
+        REQUIRE(signal3.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to each Signal") {
+        REQUIRE(slot.isConnectedTo(signal1));
+        REQUIRE(slot.isConnectedTo(signal2));
+        REQUIRE(slot.isConnectedTo(signal3));
+    }
+
+    SECTION("each Signal should not be connected to another Slot") {
+        Slot<> anotherSlot([]() {});
+
+        REQUIRE_FALSE(signal1.isConnectedTo(anotherSlot));
+        REQUIRE_FALSE(signal2.isConnectedTo(anotherSlot));
+        REQUIRE_FALSE(signal3.isConnectedTo(anotherSlot));
+    }
+
+    SECTION("Slot should not be connected to another Signal") {
+        Signal<> anotherSignal;
+
+        REQUIRE_FALSE(slot.isConnectedTo(anotherSignal));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -291,3 +291,23 @@ TEST_CASE("Signal can disconnect from all Slots") {
         REQUIRE_FALSE(slot3.isConnectedTo(signal));
     }
 }
+
+TEST_CASE("Signal should disconnect when destructed") {
+    Slot<> slot([]() {});
+    {
+        Signal<> signal;
+        signal.connect(slot);
+    }
+
+    REQUIRE(slot.connectionCount() == 0);
+}
+
+TEST_CASE("Slot should disconnect when destructed") {
+    Signal<> signal;
+    {
+        Slot<> slot([]() {});
+        signal.connect(slot);
+    }
+
+    REQUIRE(signal.connectionCount() == 0);
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -144,3 +144,115 @@ TEST_CASE("Slot can be connected to multiple Signals") {
         REQUIRE_FALSE(slot.isConnectedTo(anotherSignal));
     }
 }
+
+TEST_CASE("Signal and Slot can be disconnected") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+
+    signal.connect(slot);
+    signal.disconnect(slot);
+
+    SECTION("Signal should have zero connections") {
+        REQUIRE(signal.connectionCount() == 0);
+    }
+
+    SECTION("Slot should have zero connections") {
+        REQUIRE(slot.connectionCount() == 0);
+    }
+
+    SECTION("Signal should not be connected to Slot") {
+        REQUIRE_FALSE(signal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should not be connected to Signal") {
+        REQUIRE_FALSE(slot.isConnectedTo(signal));
+    }
+}
+
+TEST_CASE("Signal can be disconnected from a single Slot") {
+    Signal<> signal;
+    Slot<> connectedSlot1([]() {});
+    Slot<> disconnectedSlot([]() {});
+    Slot<> connectedSlot2([]() {});
+
+    signal.connect(connectedSlot1);
+    signal.connect(disconnectedSlot);
+    signal.connect(connectedSlot2);
+
+    signal.disconnect(disconnectedSlot);
+
+    SECTION("Signal should have two connections") {
+        REQUIRE(signal.connectionCount() == 2);
+    }
+
+    SECTION("each Slot not disconnected should have a single connection") {
+        REQUIRE(connectedSlot1.connectionCount() == 1);
+        REQUIRE(connectedSlot2.connectionCount() == 1);
+    }
+
+    SECTION("the disconnected Slot should have zero connections") {
+        REQUIRE(disconnectedSlot.connectionCount() == 0);
+    }
+
+    SECTION("Signal should be connected to each Slot not disconnected") {
+        REQUIRE(signal.isConnectedTo(connectedSlot1));
+        REQUIRE(signal.isConnectedTo(connectedSlot2));
+    }
+
+    SECTION("Signal should not be connected to the disconnected Slot") {
+        REQUIRE_FALSE(signal.isConnectedTo(disconnectedSlot));
+    }
+
+    SECTION("each not disconnected Slot should be connected to Signal") {
+        REQUIRE(connectedSlot1.isConnectedTo(signal));
+        REQUIRE(connectedSlot2.isConnectedTo(signal));
+    }
+
+    SECTION("the disconnected Slot should not be connected to Signal") {
+        REQUIRE_FALSE(disconnectedSlot.isConnectedTo(signal));
+    }
+}
+
+TEST_CASE("Slot can be disconnected from a single Signal") {
+    Signal<> connectedSignal1;
+    Signal<> disconnectedSignal;
+    Signal<> connectedSignal2;
+    Slot<> slot([]() {});
+
+    connectedSignal1.connect(slot);
+    disconnectedSignal.connect(slot);
+    connectedSignal2.connect(slot);
+
+    disconnectedSignal.disconnect(slot);
+
+    SECTION("each Signal not disconnected should have a single connection") {
+        REQUIRE(connectedSignal1.connectionCount() == 1);
+        REQUIRE(connectedSignal2.connectionCount() == 1);
+    }
+
+    SECTION("the disconnected Signal should have zero connections") {
+        REQUIRE(disconnectedSignal.connectionCount() == 0);
+    }
+
+    SECTION("Slot should have a two connections") {
+        REQUIRE(slot.connectionCount() == 2);
+    }
+
+    SECTION("each Signal not disconnected should be connected to Slot") {
+        REQUIRE(connectedSignal1.isConnectedTo(slot));
+        REQUIRE(connectedSignal2.isConnectedTo(slot));
+    }
+
+    SECTION("the disconnected Signal should not be connected to Slot") {
+        REQUIRE_FALSE(disconnectedSignal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to each Signal not disconnected") {
+        REQUIRE(slot.isConnectedTo(connectedSignal1));
+        REQUIRE(slot.isConnectedTo(connectedSignal2));
+    }
+
+    SECTION("Slot should not be connected to the disconnected Signal") {
+        REQUIRE_FALSE(slot.isConnectedTo(disconnectedSignal));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -619,3 +619,69 @@ TEST_CASE("Slot can be move constructed") {
         REQUIRE(moved.isConnectedTo(signal));
     }
 }
+
+TEST_CASE("Signal can be move assigned") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Signal<> moved;
+
+    moved = std::move(signal);
+
+    SECTION("moved Signal should have a single connection") {
+        REQUIRE(moved.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have a single connection") {
+        REQUIRE(slot.connectionCount() == 1);
+    }
+
+    SECTION("moved Signal should be connected to Slot") {
+        REQUIRE(moved.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to moved Signal") {
+        REQUIRE(slot.isConnectedTo(moved));
+    }
+}
+
+TEST_CASE("Signal can be move assigned after being previously connected") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Signal<> moved;
+    Slot<> previousSlot([]() {});
+    moved.connect(previousSlot);
+
+    moved = std::move(signal);
+
+    SECTION("moved Signal should have a single connection") {
+        REQUIRE(moved.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have a single connection") {
+        REQUIRE(slot.connectionCount() == 1);
+    }
+
+    SECTION("previous Slot should have zero connections") {
+        REQUIRE(previousSlot.connectionCount() == 0);
+    }
+
+    SECTION("moved Signal should be connected to Slot") {
+        REQUIRE(moved.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to moved Signal") {
+        REQUIRE(slot.isConnectedTo(moved));
+    }
+
+    SECTION("previous Slot should not be connected to moved Signal") {
+        REQUIRE_FALSE(previousSlot.isConnectedTo(moved));
+    }
+
+    SECTION("moved Signal should not be connected to the previous Slot") {
+        REQUIRE_FALSE(moved.isConnectedTo(previousSlot));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -311,3 +311,39 @@ TEST_CASE("Slot should disconnect when destructed") {
 
     REQUIRE(signal.connectionCount() == 0);
 }
+
+TEST_CASE("Signal can be copy constructed") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Signal<> copy(signal);
+
+    SECTION("Signal should have a single connection") {
+        REQUIRE(signal.connectionCount() == 1);
+    }
+
+    SECTION("copied Signal should have a single connection") {
+        REQUIRE(copy.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have two connections") {
+        REQUIRE(slot.connectionCount() == 2);
+    }
+
+    SECTION("Signal should be connected to Slot") {
+        REQUIRE(signal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to Signal") {
+        REQUIRE(slot.isConnectedTo(signal));
+    }
+
+    SECTION("copied Signal should be connected to Slot") {
+        REQUIRE(copy.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to copied Signal") {
+        REQUIRE(slot.isConnectedTo(copy));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -347,3 +347,39 @@ TEST_CASE("Signal can be copy constructed") {
         REQUIRE(slot.isConnectedTo(copy));
     }
 }
+
+TEST_CASE("Slot can be copy constructed") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Slot<> copy(slot);
+
+    SECTION("Signal should have two connections") {
+        REQUIRE(signal.connectionCount() == 2);
+    }
+
+    SECTION("copied Slot should have a single connection") {
+        REQUIRE(copy.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have a single connection") {
+        REQUIRE(slot.connectionCount() == 1);
+    }
+
+    SECTION("Signal should be connected to Slot") {
+        REQUIRE(signal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to Signal") {
+        REQUIRE(slot.isConnectedTo(signal));
+    }
+
+    SECTION("Signal should be connected to copied Slot") {
+        REQUIRE(signal.isConnectedTo(copy));
+    }
+
+    SECTION("copied Slot should be connected to Signal") {
+        REQUIRE(copy.isConnectedTo(signal));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -256,3 +256,38 @@ TEST_CASE("Slot can be disconnected from a single Signal") {
         REQUIRE_FALSE(slot.isConnectedTo(disconnectedSignal));
     }
 }
+
+TEST_CASE("Signal can disconnect from all Slots") {
+    Signal<> signal;
+    Slot<> slot1([]() {});
+    Slot<> slot2([]() {});
+    Slot<> slot3([]() {});
+
+    signal.connect(slot1);
+    signal.connect(slot2);
+    signal.connect(slot3);
+
+    signal.disconnectAll();
+
+    SECTION("Signal should have zero connections") {
+        REQUIRE(signal.connectionCount() == 0);
+    }
+
+    SECTION("each Slot should have zero connections") {
+        REQUIRE(slot1.connectionCount() == 0);
+        REQUIRE(slot2.connectionCount() == 0);
+        REQUIRE(slot3.connectionCount() == 0);
+    }
+
+    SECTION("Signal should not be connected to any of the Slots") {
+        REQUIRE_FALSE(signal.isConnectedTo(slot1));
+        REQUIRE_FALSE(signal.isConnectedTo(slot2));
+        REQUIRE_FALSE(signal.isConnectedTo(slot3));
+    }
+
+    SECTION("each Slot should not be connected to Signal") {
+        REQUIRE_FALSE(slot1.isConnectedTo(signal));
+        REQUIRE_FALSE(slot2.isConnectedTo(signal));
+        REQUIRE_FALSE(slot3.isConnectedTo(signal));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -595,3 +595,27 @@ TEST_CASE("Signal can be move constructed") {
         REQUIRE(slot.isConnectedTo(moved));
     }
 }
+
+TEST_CASE("Slot can be move constructed") {
+    Slot<> slot([]() {});
+    Signal<> signal;
+    signal.connect(slot);
+
+    Slot<> moved(std::move(slot));
+
+    SECTION("moved Slot should have a single connection") {
+        REQUIRE(moved.connectionCount() == 1);
+    }
+
+    SECTION("Signal should have a single connection") {
+        REQUIRE(signal.connectionCount() == 1);
+    }
+
+    SECTION("moved Slot should be connected to Signal") {
+        REQUIRE(moved.isConnectedTo(signal));
+    }
+
+    SECTION("Signal should be connected to moved Slot") {
+        REQUIRE(moved.isConnectedTo(signal));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -571,3 +571,27 @@ TEST_CASE("Slot can be copy assigned after being previously connected") {
         REQUIRE_FALSE(copy.isConnectedTo(previousSignal));
     }
 }
+
+TEST_CASE("Signal can be move constructed") {
+    Slot<> slot([]() {});
+    Signal<> signal;
+    signal.connect(slot);
+
+    Signal<> moved(std::move(signal));
+
+    SECTION("moved Signal should have a single connection") {
+        REQUIRE(moved.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have a single connection") {
+        REQUIRE(slot.connectionCount() == 1);
+    }
+
+    SECTION("moved Signal should be connected to Slot") {
+        REQUIRE(moved.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to moved Signal") {
+        REQUIRE(slot.isConnectedTo(moved));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -471,3 +471,91 @@ TEST_CASE("Signal can be copy assigned after being previously connected") {
         REQUIRE_FALSE(copy.isConnectedTo(previousSlot));
     }
 }
+
+TEST_CASE("Slot can be copy assigned") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Slot<> copy = slot;
+
+    SECTION("Signal should have two connections") {
+        REQUIRE(signal.connectionCount() == 2);
+    }
+
+    SECTION("copied Slot should have a single connection") {
+        REQUIRE(copy.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have a single connection") {
+        REQUIRE(slot.connectionCount() == 1);
+    }
+
+    SECTION("Signal should be connected to Slot") {
+        REQUIRE(signal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to Signal") {
+        REQUIRE(slot.isConnectedTo(signal));
+    }
+
+    SECTION("Signal should be connected to copied Slot") {
+        REQUIRE(signal.isConnectedTo(copy));
+    }
+
+    SECTION("copied Slot should be connected to Signal") {
+        REQUIRE(copy.isConnectedTo(signal));
+    }
+}
+
+TEST_CASE("Slot can be copy assigned after being previously connected") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Slot<> copy([]() {});
+    Signal<> previousSignal;
+    previousSignal.connect(copy);
+
+    copy = slot;
+
+    SECTION("Signal should have two connections") {
+        REQUIRE(signal.connectionCount() == 2);
+    }
+
+    SECTION("copied Slot should have a single connection") {
+        REQUIRE(copy.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have a single connection") {
+        REQUIRE(slot.connectionCount() == 1);
+    }
+
+    SECTION("previous Signal should have zero connections") {
+        REQUIRE(previousSignal.connectionCount() == 0);
+    }
+
+    SECTION("Signal should be connected to Slot") {
+        REQUIRE(signal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to Signal") {
+        REQUIRE(slot.isConnectedTo(signal));
+    }
+
+    SECTION("Signal should be connected to copied Slot") {
+        REQUIRE(signal.isConnectedTo(copy));
+    }
+
+    SECTION("copied Slot should be connected to Signal") {
+        REQUIRE(copy.isConnectedTo(signal));
+    }
+
+    SECTION("previous Signal should not be connected to copied Slot") {
+        REQUIRE_FALSE(previousSignal.isConnectedTo(copy));
+    }
+
+    SECTION("copied Slot should not be connected to the previous Signal") {
+        REQUIRE_FALSE(copy.isConnectedTo(previousSignal));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -383,3 +383,91 @@ TEST_CASE("Slot can be copy constructed") {
         REQUIRE(copy.isConnectedTo(signal));
     }
 }
+
+TEST_CASE("Signal can be copy assigned") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Signal<> copy = signal;
+
+    SECTION("Signal should have a single connection") {
+        REQUIRE(signal.connectionCount() == 1);
+    }
+
+    SECTION("copied Signal should have a single connection") {
+        REQUIRE(copy.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have two connections") {
+        REQUIRE(slot.connectionCount() == 2);
+    }
+
+    SECTION("Signal should be connected to Slot") {
+        REQUIRE(signal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to Signal") {
+        REQUIRE(slot.isConnectedTo(signal));
+    }
+
+    SECTION("copied Signal should be connected to Slot") {
+        REQUIRE(copy.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to copied Signal") {
+        REQUIRE(slot.isConnectedTo(copy));
+    }
+}
+
+TEST_CASE("Signal can be copy assigned after being previously connected") {
+    Signal<> signal;
+    Slot<> slot([]() {});
+    signal.connect(slot);
+
+    Signal<> copy;
+    Slot<> previousSlot([]() {});
+    copy.connect(previousSlot);
+
+    copy = signal;
+
+    SECTION("Signal should have a single connection") {
+        REQUIRE(signal.connectionCount() == 1);
+    }
+
+    SECTION("copied Signal should have a single connection") {
+        REQUIRE(copy.connectionCount() == 1);
+    }
+
+    SECTION("Slot should have two connections") {
+        REQUIRE(slot.connectionCount() == 2);
+    }
+
+    SECTION("previous Slot should have zero connections") {
+        REQUIRE(previousSlot.connectionCount() == 0);
+    }
+
+    SECTION("Signal should be connected to Slot") {
+        REQUIRE(signal.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to Signal") {
+        REQUIRE(slot.isConnectedTo(signal));
+    }
+
+    SECTION("copied Signal should be connected to Slot") {
+        REQUIRE(copy.isConnectedTo(slot));
+    }
+
+    SECTION("Slot should be connected to copied Signal") {
+        REQUIRE(slot.isConnectedTo(copy));
+    }
+
+    SECTION("previous Slot should not be connected to copied Signal") {
+        REQUIRE_FALSE(previousSlot.isConnectedTo(copy));
+    }
+
+    SECTION("copied Signal should not be connected to the previous Slot") {
+        REQUIRE_FALSE(copy.isConnectedTo(previousSlot));
+    }
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -49,6 +49,18 @@ TEST_CASE("Signal and Slot can be connected") {
 
         REQUIRE_FALSE(slot.isConnectedTo(anotherSignal));
     }
+
+    SECTION("Signal and Slot should only be able to connect once") {
+        signal.connect(slot);
+
+        SECTION("Signal should have a single connection") {
+            REQUIRE(signal.connectionCount() == 1);
+        }
+
+        SECTION("Slot should have a single connection") {
+            REQUIRE(slot.connectionCount() == 1);
+        }
+    }
 }
 
 TEST_CASE("Signal can be connected to multiple Slots") {


### PR DESCRIPTION
Initial implementation that intends to provide for the basic functionality.

`Signal` and `Slot` can each have many connections, though only one between each unique pair.

Connections between `Signal`s and `Slot`s are automatically handled when they are destructed, copied or moved.