### PR TITLE
Allow Slot to be const by making signals mutable

### DIFF
--- a/ass.hpp
+++ b/ass.hpp
@@ -118,11 +118,11 @@ namespace ass {
 
     private:
 
-        void addSignal(Signal<Args...> &signal) {
+        void addSignal(Signal<Args...> &signal) const {
             signals.push_back(&signal);
         }
 
-        void removeSignal(Signal<Args...> &signal) {
+        void removeSignal(Signal<Args...> &signal) const {
             signals.erase(std::remove(signals.begin(), signals.end(), &signal), signals.end());
         }
 
@@ -143,7 +143,7 @@ namespace ass {
 
         std::function<void(Args...)> callback;
 
-        std::vector<Signal<Args...> *> signals;
+        mutable std::vector<Signal<Args...> *> signals;
 
     };
 
@@ -216,7 +216,7 @@ namespace ass {
          *
          * @param slot Slot to connect this Signal to.
          */
-        void connect(Slot<Args...> &slot) {
+        void connect(const Slot<Args...> &slot) {
             if (!isConnectedTo(slot)) {
                 slots.push_back(&slot);
                 slot.addSignal(*this);
@@ -228,7 +228,7 @@ namespace ass {
          *
          * @param slot Slot to disconnect this Signal from.
          */
-        void disconnect(Slot<Args...> &slot) {
+        void disconnect(const Slot<Args...> &slot) {
             this->removeSlot(slot);
             slot.removeSignal(*this);
         }
@@ -264,7 +264,7 @@ namespace ass {
 
     private:
 
-        void removeSlot(Slot<Args...> &slot) {
+        void removeSlot(const Slot<Args...> &slot) {
             slots.erase(std::remove(slots.begin(), slots.end(), &slot), slots.end());
         }
 
@@ -276,7 +276,7 @@ namespace ass {
 
     private:
 
-        std::vector<Slot<Args...> *> slots;
+        std::vector<const Slot<Args...> *> slots;
 
     };
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -845,6 +845,36 @@ TEST_CASE("Signal should forward multiple arguments to Slot") {
     REQUIRE(integer == 5);
 }
 
+TEST_CASE("Slot can be const") {
+    CountingCallable callable;
+    Signal<> signal;
+    const Slot<> slot(callable);
+
+    SECTION("Slot should be able to connect to Signal") {
+        signal.connect(slot);
+        REQUIRE(slot.isConnectedTo(signal));
+        REQUIRE(slot.connectionCount() == 1);
+        REQUIRE(signal.isConnectedTo(slot));
+        REQUIRE(signal.connectionCount() == 1);
+    }
+
+    SECTION("Slot should be able to connect to Signal and be called") {
+        signal.connect(slot);
+        signal.emit();
+
+        REQUIRE(callable.count() == 1);
+    }
+
+    SECTION("Slot should be able to disconnect from Signal") {
+        signal.connect(slot);
+        signal.disconnect(slot);
+        REQUIRE_FALSE(slot.isConnectedTo(signal));
+        REQUIRE(slot.connectionCount() == 0);
+        REQUIRE_FALSE(signal.isConnectedTo(slot));
+        REQUIRE(signal.connectionCount() == 0);
+    }
+}
+
 TEST_CASE("Slot can callback on an instance function") {
     class Triggerable {
     public:


### PR DESCRIPTION
Being able to make `Slot` `const` is super handy when not exposing the slot through a getter ...

```c++
class Popup {
public:
    const Slot<> show = Slot<>(...);
}
```

This is achieved by making `addSignal` and `removeSignal` in `Slot` `const` and making `signals` mutable.
This is a bit of a smell for me, but I justified it to myself by thinking of `signals` as part of the _connections_ rather than `Slot` itself.